### PR TITLE
Added video preview generation

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_video_compress/FlutterVideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_video_compress/FlutterVideoCompressPlugin.kt
@@ -48,8 +48,13 @@ class FlutterVideoCompressPlugin : MethodCallHandler {
                 val path = call.argument<String>("path")!!
                 val quality = call.argument<Int>("quality")!!
                 val deleteOrigin = call.argument<Boolean>("deleteOrigin")!!
+                val startTime = call.argument<Int>("startTime")
+                val duration = call.argument<Int>("duration")
+                val includeAudio = call.argument<Boolean>("includeAudio")
+                val frameRate = call.argument<Int>("frameRate")
 
-                ffmpegCommander?.startCompress(path, quality, deleteOrigin, result, reg.messenger())
+                ffmpegCommander?.startCompress(path, VideoQuality.from(quality), deleteOrigin,
+                        startTime, duration, includeAudio, frameRate, result, reg.messenger())
             }
             "stopCompress" -> {
                 ffmpegCommander?.stopCompress()

--- a/android/src/main/kotlin/com/example/flutter_video_compress/Utility.kt
+++ b/android/src/main/kotlin/com/example/flutter_video_compress/Utility.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.os.Build
 import io.flutter.plugin.common.MethodChannel
 import org.json.JSONObject
 import java.io.File
@@ -43,6 +44,11 @@ class Utility(private val channelName: String) {
         val width = java.lang.Long.parseLong(widthStr)
         val height = java.lang.Long.parseLong(heightStr)
         val filesize = file.length()
+        val orientation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
+        } else {
+            null
+        }
 
         val json = JSONObject()
 
@@ -55,6 +61,9 @@ class Utility(private val channelName: String) {
         json.put("height", height)
         json.put("duration", duration)
         json.put("filesize", filesize)
+        if (orientation != null) {
+            json.put("orientation", orientation)
+        }
 
         return json
     }
@@ -108,12 +117,5 @@ class Utility(private val channelName: String) {
             }
         }
         return fileName
-    }
-
-    fun getScaleByQuality(quality: Int): String = when (quality) {
-        1 -> "scale=128:-2"
-        2 -> "scale=320:-2"
-        3 -> "scale=1080:-2"
-        else -> "scale=128:-2"
     }
 }

--- a/android/src/main/kotlin/com/example/flutter_video_compress/VideoQuality.kt
+++ b/android/src/main/kotlin/com/example/flutter_video_compress/VideoQuality.kt
@@ -1,0 +1,26 @@
+package com.example.flutter_video_compress
+
+enum class VideoQuality(val value : Int) {
+    DEFAULT_QUALITY(-1),
+    RES_128(0),
+    RES_320(1),
+    RES_360(2),
+    RES_640(3),
+    RES_1080(4);
+
+    companion object {
+        fun from(findValue: Int): VideoQuality = values().first { it.value == findValue }
+    }
+
+    fun getScaleString(): String = when (this) {
+        RES_128 -> "128"
+        RES_320 -> "320"
+        RES_640 -> "640"
+        RES_1080 -> "1080"
+        else -> "320"
+    }
+
+    fun notDefault(): Boolean = this != DEFAULT_QUALITY
+
+    fun isHighQuality(): Boolean = this == RES_1080
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -26,11 +26,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   flutter_video_compress: c8ad9a73887a76dd99a38ae86a6397541ca7d117
   image_picker: 16e5fec1fbc87fd3b297c53e4048521eaf17cd06
   Regift: d097afd401021f4f42b102ee125ceeb125a38caf
 
-PODFILE CHECKSUM: 77e004a6b20b73c17b23d44f4a2f0cdceeee9fb5
+PODFILE CHECKSUM: 596239def9fc038f4ca3b58962ce3ad0da67feb5
 
 COCOAPODS: 1.7.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../.symlinks/flutter/ios-release/Flutter.framework",
+				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/Regift/Regift.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_video_compress/flutter_video_compress.framework",
 				"${BUILT_PRODUCTS_DIR}/image_picker/image_picker.framework",

--- a/lib/src/flutter_video_compress.dart
+++ b/lib/src/flutter_video_compress.dart
@@ -176,8 +176,12 @@ class FlutterVideoCompress {
   /// ```
   Future<MediaInfo> startCompress(
     String path, {
-    VideoQuality quality = VideoQuality.DefaultQuality,
+    VideoQuality quality = DEFAULT_QUALITY,
     bool deleteOrigin = false,
+    int startTime,
+    int duration,
+    bool includeAudio,
+    int frameRate,
   }) async {
     assert(path != null);
     if (_isCompressing) {
@@ -192,8 +196,12 @@ class FlutterVideoCompress {
     }
     final jsonStr = await _invoke<String>('startCompress', {
       'path': path,
-      'quality': quality.index,
+      'quality': quality.value,
       'deleteOrigin': deleteOrigin,
+      'startTime': startTime,
+      'duration': duration,
+      'includeAudio': includeAudio,
+      'frameRate': frameRate,
     });
     _isCompressing = false;
     final jsonMap = json.decode(jsonStr);

--- a/lib/src/video_quality.dart
+++ b/lib/src/video_quality.dart
@@ -1,3 +1,19 @@
 part of flutter_video_compress;
 
-enum VideoQuality { DefaultQuality, LowQuality, MediumQuality, HighestQuality }
+class VideoQuality<int> extends Enum<int> {
+  const VideoQuality(int val) : super(val);
+}
+
+const VideoQuality DEFAULT_QUALITY = const VideoQuality(-1);
+const VideoQuality RES_128 = const VideoQuality(0);
+const VideoQuality RES_320 = const VideoQuality(1);
+const VideoQuality RES_640 = const VideoQuality(2);
+const VideoQuality RES_1080 = const VideoQuality(3);
+
+abstract class Enum<T> {
+  final T _value;
+
+  const Enum(this._value);
+
+  T get value => _value;
+}


### PR DESCRIPTION
Added start and duration to startCompress method along with
includeAudio and frame rate parameters. This is made in order
to create smaller videos that can be used for previews.
Currently on Android all parameters are used, on iOS it's not
possible with current library to set frame rate, and removing
audio from video is relativly complicated, so for the initial
implementation it is left out of iOS impelementation.